### PR TITLE
Remove debugging line

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -113,7 +113,5 @@
    else if (!is.character(basePath))
       stop("basePath parameter is not of type character", call. = FALSE)
    
-   str(markers)
-   
    invisible(.Call("rs_sourceMarkers", name, markers, basePath, autoSelect))
 })


### PR DESCRIPTION
Took me a little while to figure out why the markers were always printing `str` formatted information to the console in the preview release.
